### PR TITLE
chore: replace sensitive keys with placeholders

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
         name: TIFW
     ai:
         ollama:
-            base-url: http://47.239.92.130:11434
+            base-url: http://example.com:11434 # 示例地址
             chat:
                 model: deepseek-r1:1.5b
                 options:
@@ -14,15 +14,15 @@ spring:
             redis:
                 host: localhost
                 port: 6379
-                password: 123456
+                password: example-redis-password # 示例 Redis 密码
                 timeout: 5000
         vectorstore:
             milvus:
                 client:
-                    host: 47.239.92.130 # default: localhost
+                    host: example-host # default: localhost
                     port: 19530 # default: 19530
                     username: root # default: root
-                    password: Milvus # default: milvus
+                    password: example-milvus-password # 示例 Milvus 密码
                 databaseName: default # default: default
                 collectionName: vector_store # default: vector_store
                 embeddingDimension: 1536 # default: 1536
@@ -30,7 +30,7 @@ spring:
                 metricType: COSINE # default: COSINE
     datasource:
         driverClassName: com.mysql.cj.jdbc.Driver
-        password: 123456
+        password: example-db-password # 示例数据库密码
         type: com.alibaba.druid.pool.DruidDataSource
         url: jdbc:mysql://localhost:3307/tifw?serverTimezone=GMT%2B8&useUnicode=true&characterEncoding=utf8&useSSL=false&allowPublicKeyRetrieval=true
         username: root

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -18,7 +18,7 @@
     </div>
     <form id="loginForm" onsubmit="return handleLogin(event)">
         <div class="form-floating">
-            <input type="text" class="form-control" id="phone" placeholder="请输入手机号" required value="13700000000">
+            <input type="text" class="form-control" id="phone" placeholder="请输入手机号" required>
             <label for="phone">手机号</label>
         </div>
 <!--        <div class="form-floating">-->
@@ -26,7 +26,7 @@
 <!--            <label for="username">用户名</label>-->
 <!--        </div>-->
         <div class="form-floating">
-            <input type="password" class="form-control" id="password" placeholder="密码" required value="123456">
+            <input type="password" class="form-control" id="password" placeholder="密码" required>
             <label for="password">密码</label>
 
         </div>


### PR DESCRIPTION
## Summary
- replace hardcoded service URLs and passwords with example placeholders
- remove default account values from login page

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b59a7171748330acd9df9cf267529c